### PR TITLE
Replace `sigfigs` by `decimal_places`, 

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ An example of the schema can be found in the `schema.json` file on this repo.
     - `lower_05`: (float) Lower bound of the 95% confidence region.
     - `is_upper_bound`: (bool) Whether this best value is an upper limit bound. Defaults to `false` if omitted.
     - `is_lower_bound`: (bool) Whether this best value is an lower limit bound. Defaults to `false` if omitted.
-    - `sigfigs`: (int) Number of significant figures of the best value.
+    - `decimal_places`: (int) Number of decimal places of the best value to display, must be >= 0.
     - `unit`: The physical unit of the `median` value. See below for allowed values.
     - `links`: (object | null) Links to external resources. This section can be omitted.
 

--- a/ccverify/core.py
+++ b/ccverify/core.py
@@ -118,7 +118,7 @@ def verify_upload_schema(newcat):
                     "lower_05",
                     "is_upper_bound",
                     "is_lower_bound",
-                    "sigfigs",
+                    "decimal_places",
                     "unit",
                 ]
                 for akey in mandatory_keys:

--- a/ccverify/schema.py
+++ b/ccverify/schema.py
@@ -48,12 +48,12 @@ class ParameterValue:
     unit: str or None
     """
     parameter_name: str
+    decimal_places: int
     median: float
     upper_95: float = None
     lower_05: float = None
     is_upper_bound: bool = False
     is_lower_bound: bool = False
-    decimal_places: int = None
     unit: str = None
 
     @classmethod

--- a/ccverify/schema.py
+++ b/ccverify/schema.py
@@ -42,8 +42,8 @@ class ParameterValue:
 
     is_upper_bound, is_lower_bound: bool
 
-    sigfigs: int
-        Number of significant figures.
+    decimal_places: int
+        Number of places after the decimal point to display.
 
     unit: str or None
     """
@@ -53,7 +53,7 @@ class ParameterValue:
     lower_05: float = None
     is_upper_bound: bool = False
     is_lower_bound: bool = False
-    sigfigs: int = None
+    decimal_places: int = None
     unit: str = None
 
     @classmethod
@@ -183,17 +183,15 @@ def _condition_value_and_error(value, error) -> dict:
         return {'median': float(f'{value:.2g}'),
                 'lower_05': float(f'{-error[0]:.2g}'),
                 'upper_95': float(f'{error[1]:.2g}'),
-                'sigfigs': None}
+                'decimal_places': max(0, _first_decimal_place(value) + 1)}
 
-    last_decimal = _first_decimal_place(min_error)
+    decimal_places = _first_decimal_place(min_error)
     if f'{min_error:e}'.startswith('1'):
-        last_decimal += 1
-
-    first_decimal = _first_decimal_place(value)
+        decimal_places += 1
 
     def truncate(val):
-        rounded = round(val, last_decimal)
-        if last_decimal > 0:
+        rounded = round(val, decimal_places)
+        if decimal_places > 0:
             return rounded
         return int(rounded)
 
@@ -203,7 +201,7 @@ def _condition_value_and_error(value, error) -> dict:
     return {'median': truncated_value,
             'lower_05': err_minus,
             'upper_95': err_plus,
-            'sigfigs': last_decimal - first_decimal + 1}
+            'decimal_places': max(0, decimal_places)}
 
 
 def _first_decimal_place(value) -> int:

--- a/schema.json
+++ b/schema.json
@@ -17,21 +17,21 @@
                 "parameter_name": "far",
                 "median": 0.00001,
                 "is_upper_bound": true,
-                "sigfigs": 1,
+                "decimal_places": 5,
                 "unit": "1/year"
               },
               {
                 "parameter_name": "pastro",
                 "median": 0.99,
                 "is_lower_bound": true,
-                "sigfigs": 2
+                "decimal_places": 2
               },
               {
                 "parameter_name": "snr",
                 "median": 9.34,
                 "upper_95": 0.01,
                 "lower_05": 0.01,
-                "sigfigs": 3
+                "decimal_places": 2
               }
             ]
           },
@@ -48,7 +48,7 @@
                   "lower_05": 0.01,
                   "is_upper_bound": false,
                   "is_lower_bound": false,
-                  "sigfigs": 3,
+                  "decimal_places": 2,
                   "unit": "M_sun"
                 },
                 {
@@ -58,7 +58,7 @@
                   "lower_05": 2.0,
                   "is_upper_bound": false,
                   "is_lower_bound": false,
-                  "sigfigs": 3,
+                  "decimal_places": 0,
                   "unit": "Mpc"
                 }
               ],


### PR DESCRIPTION
Also updates the implementation. Fixes #28.

Notes:
We might want to add a test that `decimal_places >= 0`.
Also, is `decimal_places=null` allowed? (E.g. usually far and pastro don't have errors reported).

