### PR TITLE
Include is_preferred key for parameter_set group

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ An example of the schema can be found in the `schema.json` file on this repo.
     - `pe_set_name`: (string) The pipeline used to generate the parameter estimations.
     - `waveform_family`: (string) The name of the waveform family used in the estimation.
     - `data_url`: (string, url) The full URL to the posterior sample tarball online.
+    - `is_preferred`: (bool) Set to `true` if the preferred parameter values should be picked from this parameter set.
 
 5. Parameters level
 

--- a/ccverify/schema.py
+++ b/ccverify/schema.py
@@ -96,6 +96,7 @@ class ParameterSet:
     pe_set_name: str
     data_url: str
     waveform_family: str
+    is_preferred: bool
     parameters: list[ParameterValue]
     links: list[Link] = None
 
@@ -105,6 +106,7 @@ class ParameterSet:
                      pe_set_name,
                      data_url,
                      waveform_family,
+                     is_preferred,
                      links=None):
         """
         Constructor from a ``pandas.DataFrame`` of posterior samples.
@@ -114,6 +116,7 @@ class ParameterSet:
         return cls(pe_set_name=pe_set_name,
                    data_url=data_url,
                    waveform_family=waveform_family,
+                   is_preferred=is_preferred,
                    parameters=parameters,
                    links=links,
                   )

--- a/schema.json
+++ b/schema.json
@@ -62,6 +62,7 @@
                   "unit": "Mpc"
                 }
               ],
+              "is_preferred": true,
               "links": [
                 {
                   "url": "https://example.com",


### PR DESCRIPTION
Despite the discussion in #33 @jroulet I think we should still add this. If in the future we see it's not enough, we can change it.

I changed `is_default` to `is_preferred` because in our back end `default` means the list of parameter names on the main table and `preferred` refers to the values we pick to fill out the table with. 

Take a look and let me know if there's anything else we need to add.