### PR TITLE
Validation

### DIFF
--- a/ccverify/schema.py
+++ b/ccverify/schema.py
@@ -114,8 +114,7 @@ class SearchResult:
 
     @classmethod
     def from_json(cls, search):
-        search_parameters = search.pop("parameters")
-        parameters = [ParameterValue(**p) for p in search_parameters]
+        parameters = [ParameterValue(**p) for p in search.pop("parameters")]
         return SearchResult(**search, parameters=parameters)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,15 +5,15 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ccverify"
 authors = [{ name = "GWOSC", email = "gwosc@igwn.org" }]
-description = "Upload Schema Checker for GWOSC Community Catalogs"
-maintainers = [{ name = "GWOSC Dev Team", email = "gwosc@igwn.org" }]
+description = "Upload Schema for GWOSC Community Catalogs"
+maintainers = [{ name = "Community Catalog Dev Team", email = "gwosc@igwn.org" }]
 readme = "README.md"
 dynamic = ["version"]
 requires-python = ">=3.9"
 keywords = [
-    "astronomy",
     "gravitational-waves",
     "catalog",
+    "events",
 ]
 dependencies = [
   "numpy",
@@ -21,15 +21,15 @@ dependencies = [
 ]
 
 [project.urls]
-homepage = "https://astroalign.quatrope.org"
-documentation = "https://astroalign.readthedocs.io/"
-repository = "https://github.com/quatrope/astroalign"
+homepage = "https://github.com/gwosc-tutorial/gwosc-catalog"
+documentation = "https://github.com/gwosc-tutorial/gwosc-catalog"
+repository = "https://github.com/gwosc-tutorial/gwosc-catalog"
 
 [tool.setuptools]
 packages = ["ccverify"]
 
 [project.scripts]
-ccverify = "ccverify.core:main"
+validateschema = "ccverify.schema:main"
 
 [tool.setuptools.dynamic]
 version = {attr = "ccverify.__version__"}


### PR DESCRIPTION
This adds a validation CLI program that checks json schema using the classes in `schema.py`.
Uses a `.from_json` class method that ingests nested dictionaries for all the classes.

I think this will make `core.py` obsolete, but I'll leave it around for now.

There are no unit tests at the moment, I checked validating the [`ias_O3a.json`](https://github.com/seth-olsen/new_BBH_mergers_O3a_IAS_pipeline/blob/gwosc_interface/GWOSC_interface/ias-o3a.json) file (it passed for me).

There are no special `Exception` classes raised during validation.

Updates README.

This closes #48.