### PR TITLE
Fix validation modifying the input catalog

### DIFF
--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest
+        python -m pip install flake8 pytest deepdiff
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |

--- a/ccverify/schema.py
+++ b/ccverify/schema.py
@@ -127,8 +127,9 @@ class SearchResult:
     @classmethod
     def from_json(cls, search: dict):
         """Constructor from a dict."""
-        parameters = [ParameterValue(**p) for p in search.pop("parameters")]
-        return SearchResult(**search, parameters=parameters)
+        s = search.copy()
+        params = [ParameterValue(**p) for p in s.pop("parameters")]
+        return SearchResult(**s, parameters=params)
 
 
 @dataclasses.dataclass
@@ -186,9 +187,10 @@ class ParameterSet:
     @classmethod
     def from_json(cls, peset: dict):
         """Constructor from a dict."""
-        parameters = [ParameterValue(**p) for p in peset.pop("parameters")]
-        links = [Link(**u) for u in peset.pop("links", [])]
-        return ParameterSet(**peset, parameters=parameters, links=links)
+        ps = peset.copy()
+        parameters = [ParameterValue(**p) for p in ps.pop("parameters")]
+        links = [Link(**u) for u in ps.pop("links", [])]
+        return ParameterSet(**ps, parameters=parameters, links=links)
 
 
 @dataclasses.dataclass
@@ -240,10 +242,11 @@ class Event:
     @classmethod
     def from_json(cls, event: dict):
         """Constructor from a dict."""
-        searches = event.pop("search")
-        pe_sets = event.pop("pe_sets")
+        e = event.copy()
+        searches = e.pop("search")
+        pe_sets = e.pop("pe_sets")
         return Event(
-            **event,
+            **e,
             search=[SearchResult.from_json(s) for s in searches],
             pe_sets=[ParameterSet.from_json(pe_set) for pe_set in pe_sets],
         )
@@ -291,8 +294,9 @@ class Catalog:
 
     @classmethod
     def from_json(cls, catalog):
-        events = catalog.pop("events")
-        return Catalog(**catalog, events=[Event.from_json(event) for event in events])
+        c = catalog.copy()
+        events = c.pop("events")
+        return Catalog(**c, events=[Event.from_json(event) for event in events])
 
 
 def _condition_value_and_error(value, error) -> dict:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,95 @@
+from ccverify import validate_schema
+from deepdiff.diff import DeepDiff
+
+example_catalog = {
+    "schema_version": "1.0",
+    "catalog_name": "string",
+    "catalog_description": "string",
+    "doi": "https://doi.org/12345/",
+    "events": [
+        {
+            "event_name": "GW241230_010000",
+            "gps": 1234567890.1,
+            "event_description": "string or null",
+            "detectors": ["H1", "L1"],
+            "search": [
+                {
+                    "pipeline_name": "string",
+                    "parameters": [
+                        {
+                            "parameter_name": "far",
+                            "median": 0.00001,
+                            "is_upper_bound": True,
+                            "decimal_places": 5,
+                            "unit": "1/year",
+                        },
+                        {
+                            "parameter_name": "pastro",
+                            "median": 0.99,
+                            "is_lower_bound": True,
+                            "decimal_places": 2,
+                        },
+                    ],
+                }
+            ],
+            "pe_sets": [],
+        },
+        {
+            "event_name": "GW241231_010000",
+            "gps": 1234567891.1,
+            "event_description": "string or null",
+            "detectors": ["H1", "L1"],
+            "search": [
+                {
+                    "pipeline_name": "string",
+                    "parameters": [
+                        {
+                            "parameter_name": "far",
+                            "median": 0.00001,
+                            "is_upper_bound": True,
+                            "decimal_places": 5,
+                            "unit": "1/year",
+                        },
+                        {
+                            "parameter_name": "pastro",
+                            "median": 0.99,
+                            "is_lower_bound": True,
+                            "decimal_places": 2,
+                        },
+                    ],
+                }
+            ],
+            "pe_sets": [
+                {
+                    "pe_set_name": "string",
+                    "waveform_family": "IMRPhenomPv3HM",
+                    "data_url": "https://zenodo.org/",
+                    "parameters": [
+                        {
+                            "parameter_name": "mass_1_source",
+                            "median": 3.34,
+                            "upper_95": 0.01,
+                            "lower_05": 0.01,
+                            "is_upper_bound": False,
+                            "is_lower_bound": False,
+                            "decimal_places": 2,
+                            "unit": "M_sun",
+                        }
+                    ],
+                    "links": [],
+                    "is_preferred": True,
+                }
+            ],
+        },
+    ],
+    "release_date": "2024-02-04",
+}
+
+
+def test_validation_idempotent():
+    "Test that validation does not modify its input."
+    catalog_before = example_catalog
+    validate_schema(example_catalog)
+    validate_schema(example_catalog)
+    ddiff = DeepDiff(catalog_before, example_catalog, ignore_order=True)
+    assert ddiff == {}


### PR DESCRIPTION
This makes (shallow) copies of the dict passed in `.from_json` on each class so that it will not modify its input when popping 
certain fields.

It also adds a idempotent test and a comparison test made with [deepdiff](https://github.com/seperman/deepdiff).

This fixes #62.
