### PR TITLE
Fix version difference between schema and validator script

### DIFF
--- a/ccverify/__init__.py
+++ b/ccverify/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.1.0"
+__version__ = "0.1.0a1"
 
 from .schema import *

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -6,7 +6,7 @@ An example of the schema can be found below and the description of the keys afte
 
 ```json
 {
-  "schema_version": "1.0",
+  "schema_version": "0.1.0a1",
   "catalog_name": "string",
   "catalog_description": "string",
   "doi": "https://doi.org/12345/",


### PR DESCRIPTION
This adds versioning to schema to be consistent with the validator version.

This first version is tagged v0.1.0a1, i.e. the first alpha release of version 0.1.0.
