### PR TITLE
Add gracedb_id key

### DIFF
--- a/ccverify/__init__.py
+++ b/ccverify/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.1.0a2"
+__version__ = "0.1.0a3"
 
 from .schema import *

--- a/ccverify/schema.py
+++ b/ccverify/schema.py
@@ -255,6 +255,10 @@ class Event:
         Can be used for any user notes for a particular event.
         This appears in a box on the Event Detail View.
 
+    gracedb_id: str or None
+        The associated GraceDB superevent ID if any.
+        This is an optional key but we recommend adding it whenever possible.
+
     detectors: list[str]
         A list of detectors for which strain data should be publicly
         released for this event.
@@ -270,6 +274,7 @@ class Event:
     event_name: str
     gps: float
     search: list[SearchResult]
+    gracedb_id: str = None
     pe_sets: list[ParameterSet] = None
     detectors: list[str] = None
     event_description: str = None

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -6,7 +6,7 @@ An example of the schema can be found below and the description of the keys afte
 
 ```json
 {
-  "schema_version": "0.1.0a2",
+  "schema_version": "0.1.0a3",
   "catalog_name": "string",
   "catalog_description": "string",
   "doi": "https://doi.org/12345/",

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -17,6 +17,7 @@ An example of the schema can be found below and the description of the keys afte
       "gps": 1234567890.1,
       "event_description": "string or null",
       "detectors": ["H1", "L1"],
+      "gracedb_id": "S220911ab",
       "search": [
         {
           "pipeline_name": "string",
@@ -142,6 +143,8 @@ Keys marked "optional" are not required to be inlcuded; other keys are required.
     - `event_description`: (string; optional) Can be used for any user notes for a particular event.  This appears in a box on the Event Detail View. 
     - `detectors`: (list(string); optional) A list of detectors for which strain data should be
     publicly released for this event.  This parameter is not necessary for groups outside the LVK.
+    - `gracedb_id`: (str; optional) The associated GraceDB superevent ID if any.
+    This is an optional key but we recommend adding it whenever possible.
 
 3. Search level
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -12,6 +12,7 @@ example_catalog = {
             "gps": 1234567890.1,
             "event_description": "string or null",
             "detectors": ["H1", "L1"],
+            "gracedb_id": "S231001ab",
             "search": [
                 {
                     "pipeline_name": "string",

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -20,6 +20,7 @@ event_example = {
     "gps": 1234567890.1,
     "event_description": "string or null",
     "detectors": ["H1", "L1"],
+    "gracedb_id": "S231001ab",
     "search": [],
     "pe_sets": [],
 }
@@ -267,6 +268,18 @@ def test_data_url_optional():
     validate_schema(c)
 
 
+def test_gracedb_id_optional():
+    "gracedb_id key can be omited."
+    e = event_example.copy()
+    s = search_example.copy()
+    s["parameters"] = [far_example, snr_example, pastro_example]
+    e["search"] = [s]
+    del e["gracedb_id"]
+    c = catalog_example.copy()
+    c["events"] = [e]
+    validate_schema(c)
+
+
 def test_mass_unit():
     "Mass unit should be solar mass."
     with pytest.raises(ValueError):
@@ -333,6 +346,7 @@ def test_upper_lower_error_optional():
     p.pop("upper_error")
     p.pop("lower_error")
     ParameterValue(**p)
+
 
 def test_schema_version_warning():
     "Different schema warning"


### PR DESCRIPTION
- This adds an optional `gracedb_id` key to the event level.
- Adds documentation.
- Adds test to pass validatation when the key is not provided.
- Bumps version to v0.1.0a3

This closes #80.